### PR TITLE
SWIFT-119 Initialize libmongoc before running tests from macOS command line

### DIFF
--- a/Tests/Benchmarks/Benchmark.swift
+++ b/Tests/Benchmarks/Benchmark.swift
@@ -3,7 +3,6 @@ import MongoSwift
 import XCTest
 
 class Benchmark: XCTestCase {
-
     /* Ensure libmongoc is initialized. This will be called multiple times, but that's ok
      * as repeated calls have no effect. There is no way to call final cleanup code just
      * once at the very end, either explicitly or with a deinit. This may appear as a 

--- a/Tests/Benchmarks/Benchmark.swift
+++ b/Tests/Benchmarks/Benchmark.swift
@@ -1,7 +1,16 @@
 import Foundation
+import MongoSwift
 import XCTest
 
 class Benchmark: XCTestCase {
+
+    /* Ensure libmongoc is initialized. This will be called multiple times, but that's ok
+     * as repeated calls have no effect. There is no way to call final cleanup code just
+     * once at the very end, either explicitly or with a deinit. This may appear as a 
+     * memory leak. */
+    override class func setUp() {
+        MongoSwift.initialize()
+    }
 
     static var dataPath: String {
         // if we can access the "/Tests" directory, assume we're running from command line

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,11 +1,5 @@
 import Benchmarks
-import MongoSwift
 import XCTest
-
-/* Ensure libmongoc is initialized. Since XCTMain never returns, we have no
- * opportunity to cleanup libmongoc (either explicitly or with a deinit). This
- * may appear as a memory leak. */
-MongoSwift.initialize()
 
 var tests = [XCTestCaseEntry]()
 tests += Benchmarks.allTests()


### PR DESCRIPTION
same change as that in [mongo-swift-driver#153](https://github.com/mongodb/mongo-swift-driver/pull/153).