### PR TITLE
SWIFT-499 Implement parallel LDJSON benchmarks

### DIFF
--- a/Sources/Benchmarks/BSON.swift
+++ b/Sources/Benchmarks/BSON.swift
@@ -56,7 +56,7 @@ let bsonTestFiles = [
 func runJSONToBSONBenchmark(_ file: TestFile) throws -> Double {
     print("Benchmarking \(file.name) JSON to BSON")
     let json = file.json
-    let results = try measureOp {
+    let results = try measureTask {
         for _ in 1...10000 {
             _ = try Document(fromJSON: json)
         }
@@ -70,7 +70,7 @@ func runNativeToBSONBenchmark(_ file: TestFile) throws -> Double {
     print("Benchmarking \(file.name) native to BSON")
     let document = try Document(fromJSON: file.json)
     let docAsArray = document.toArray()
-    let results = try measureOp {
+    let results = try measureTask {
         for _ in 1...10000 {
             _ = Document(fromArray: docAsArray)
         }
@@ -83,7 +83,7 @@ func runNativeToBSONBenchmark(_ file: TestFile) throws -> Double {
 func runBSONToJSONBenchmark(_ file: TestFile) throws -> Double {
     print("Benchmarking \(file.name) BSON to JSON")
     let document = try Document(fromJSON: file.json)
-    let results = try measureOp {
+    let results = try measureTask {
         for _ in 1...10000 {
             _ = document.canonicalExtendedJSON
         }
@@ -96,7 +96,7 @@ func runBSONToJSONBenchmark(_ file: TestFile) throws -> Double {
 func runBSONToNativeBenchmark(_ file: TestFile) throws -> Double {
     print("Benchmarking \(file.name) BSON to native")
     let document = try Document(fromJSON: file.json)
-    let results = try measureOp {
+    let results = try measureTask {
         for _ in 1...10000 {
             _ = document.toArray()
         }

--- a/Sources/Benchmarks/IO.swift
+++ b/Sources/Benchmarks/IO.swift
@@ -157,11 +157,15 @@ func benchmarkIO() throws {
 
     // TODO: add gridfs results
     let readBenchResult = average([findOne, findMany, multiExport])
-    print("ReadBench score: \(readBenchResult))")
+    print("ReadBench score: \(readBenchResult)")
 
     // TODO: add gridfs results
     let writeBenchResult = average([smallInsertOne, largeInsertOne, smallBulk, largeBulk, multiImport])
     print("WriteBench score: \(writeBenchResult)")
+
+    // TODO: add gridfs results
+    let parallelBenchResult = average([multiImport, multiExport])
+    print("ParallelBench score: \(parallelBenchResult)")
 
     let driverBenchResult = average([readBenchResult, writeBenchResult])
     print("DriverBench score: \(driverBenchResult)")

--- a/Sources/Benchmarks/Parallel.swift
+++ b/Sources/Benchmarks/Parallel.swift
@@ -1,0 +1,82 @@
+import Foundation
+import MongoSwift
+import NIO
+
+let filePaths: [String] = (0...99).map { i in
+    var num = String(i)
+    while num.count < 3 {
+        num = "0" + num
+    }
+    return "\(dataPath)/ldjson_multi/ldjson\(num).txt"
+}
+let allocator = ByteBufferAllocator()
+
+func importAllFiles(to collection: MongoCollection<Document>, using elg: EventLoopGroup) throws {
+    EventLoopFuture.andAllSucceed(
+        filePaths.map {
+            importJSONFile(ioHandler: fileIO, path: $0, to: coll, eventLoop: elg.next())
+        },
+    on: elg.next())
+}
+
+func importJSONFile(
+    ioHandler: NonBlockingFileIO,
+    path: String,
+    to collection: MongoCollection<Document>,
+    eventLoop: EventLoop
+) -> EventLoopFuture<InsertManyResult?> {
+    ioHandler.openFile(path: path, eventLoop: eventLoop).flatMap { handle, region in
+        let readAndInsert: EventLoopFuture<InsertManyResult?> = ioHandler.read(fileRegion: region,
+                                           allocator: allocator,
+                                           eventLoop: eventLoop).flatMap {
+            var buffer = $0
+            var docs = [Document]()
+            while let next = buffer.readString(length: 1129) {
+                docs.append(try! Document(fromJSON: next))
+                // drop the newline character at the end of each line
+                buffer.moveReaderIndex(forwardBy: 1)
+            }
+
+            return collection.insertMany(docs)
+        }
+
+        readAndInsert.whenComplete { _ in
+            _ = try? handle.close()
+        }
+
+        return readAndInsert
+    }
+}
+
+// func exportCollection(
+//     ioHandler: NonBlockingFileIO,
+//     to directory: String,
+//     from collection: MongoCollection<Document>,
+//     eventLoop: EventLoop
+// ) -> EventLoopFuture<Void> {
+
+// }
+
+func runMultiJSONBenchmarks() throws {
+    // Setup
+    let elg = MultiThreadedEventLoopGroup(numberOfThreads: 4)
+    let client = try MongoClient(using: elg)
+    defer {
+        client.syncShutdown()
+    }
+    let db = client.db("perftest")
+
+    let threadPool = NIOThreadPool(numberOfThreads: NonBlockingFileIO.defaultThreadPoolSize)
+    threadPool.start()
+    let fileIO = NonBlockingFileIO(threadPool: threadPool)
+
+    let coll = try db.drop().flatMap { _ in
+        db.createCollection("corpus")
+    }.wait()
+
+    let importResult = try measureOp {
+        try importAllFiles.wait()
+    }
+
+    print("JSON Import Benchmark Result: \(importResult)")
+}

--- a/Sources/Benchmarks/Parallel.swift
+++ b/Sources/Benchmarks/Parallel.swift
@@ -2,42 +2,83 @@ import Foundation
 import MongoSwift
 import NIO
 
-let filePaths: [String] = (0...99).map { i in
-    var num = String(i)
+let inputPath = "\(dataPath)/ldjson_multi"
+let outputPath = "\(dataPath)/ldjson_multi_output"
+
+func paddedId(_ id: Int32) -> String {
+    var num = String(id)
     while num.count < 3 {
         num = "0" + num
     }
-    return "\(dataPath)/ldjson_multi/ldjson\(num).txt"
+    return num
 }
+
+func getInputFilePath(forId id: Int32) -> String {
+    "\(inputPath)/ldjson\(paddedId(id)).txt"
+}
+
+func getOutputFilePath(forId id: Int32) -> String {
+    "\(outputPath)/ldjson\(paddedId(id)).txt"
+}
+
+// Length of each LDJSON file in bytes.
+let fileLength = 5_650_000
+// Total size of dataset in MB.
+let ldJSONSize = 565.0
+// Shared allocator to use throughout the benchmarks.
 let allocator = ByteBufferAllocator()
 
-func importAllFiles(to collection: MongoCollection<Document>, using elg: EventLoopGroup) throws {
+/// Imports all LDJSON files to the specified collection.
+func importAllFiles(
+    to collection: MongoCollection<Document>,
+    eventLoopGroup: EventLoopGroup,
+    ioHandler: NonBlockingFileIO,
+    addFileIds: Bool = false
+) throws -> EventLoopFuture<Void> {
     EventLoopFuture.andAllSucceed(
-        filePaths.map {
-            importJSONFile(ioHandler: fileIO, path: $0, to: coll, eventLoop: elg.next())
+        (0...99).map {
+            importJSONFile(
+                id: $0,
+                to: collection,
+                eventLoop: eventLoopGroup.next(),
+                ioHandler: ioHandler,
+                addFileId: addFileIds
+            )
         },
-    on: elg.next())
+        on: eventLoopGroup.next()
+    )
 }
 
+/// Imports the LDJSON file with the specified id to the specified collection. If addFileId is true, appends the file
+/// ID to each inserted document under the key "fileId".
 func importJSONFile(
-    ioHandler: NonBlockingFileIO,
-    path: String,
+    id: Int32,
     to collection: MongoCollection<Document>,
-    eventLoop: EventLoop
+    eventLoop: EventLoop,
+    ioHandler: NonBlockingFileIO,
+    addFileId: Bool
 ) -> EventLoopFuture<InsertManyResult?> {
-    ioHandler.openFile(path: path, eventLoop: eventLoop).flatMap { handle, region in
-        let readAndInsert: EventLoopFuture<InsertManyResult?> = ioHandler.read(fileRegion: region,
-                                           allocator: allocator,
-                                           eventLoop: eventLoop).flatMap {
+    ioHandler.openFile(path: getInputFilePath(forId: id), eventLoop: eventLoop).flatMap { handle, region in
+        let readAndInsert: EventLoopFuture<InsertManyResult?> = ioHandler.read(
+            fileRegion: region,
+            allocator: allocator,
+            eventLoop: eventLoop
+        ).flatMap {
             var buffer = $0
-            var docs = [Document]()
-            while let next = buffer.readString(length: 1129) {
-                docs.append(try! Document(fromJSON: next))
-                // drop the newline character at the end of each line
-                buffer.moveReaderIndex(forwardBy: 1)
+            // these swiftlint disables are ok because we know the data is well-formed.
+            let docs = buffer.readBytes(length: fileLength)! // swiftlint:disable:this force_unwrapping
+                .split(separator: 10) // 10 is byte code for "\n"
+                .map { try! Document(fromJSON: Data($0)) } // swiftlint:disable:this force_try
+            if addFileId {
+                let docsWithIds: [Document] = docs.map { doc in
+                    var copy = doc
+                    copy["fileId"] = .int32(id)
+                    return copy
+                }
+                return collection.insertMany(docsWithIds)
+            } else {
+                return collection.insertMany(docs)
             }
-
-            return collection.insertMany(docs)
         }
 
         readAndInsert.whenComplete { _ in
@@ -48,16 +89,51 @@ func importJSONFile(
     }
 }
 
-// func exportCollection(
-//     ioHandler: NonBlockingFileIO,
-//     to directory: String,
-//     from collection: MongoCollection<Document>,
-//     eventLoop: EventLoop
-// ) -> EventLoopFuture<Void> {
+/// Exports the collection to a set of LDJSON files.
+func exportCollection(
+    _ collection: MongoCollection<Document>,
+    eventLoopGroup: EventLoopGroup,
+    ioHandler: NonBlockingFileIO
+) throws -> EventLoopFuture<Void> {
+    EventLoopFuture.andAllSucceed(
+        try (0...99).map {
+            try exportJSONFile(
+                id: $0,
+                from: collection,
+                eventLoop: eventLoopGroup.next(),
+                ioHandler: ioHandler
+            )
+        },
+        on: eventLoopGroup.next()
+    )
+}
 
-// }
+/// Exports all documents from the collection with the specified file id to a corresponding file.
+func exportJSONFile(
+    id: Int32,
+    from collection: MongoCollection<Document>,
+    eventLoop: EventLoop,
+    ioHandler: NonBlockingFileIO
+) throws -> EventLoopFuture<Void> {
+    let handle = try NIOFileHandle(path: getOutputFilePath(forId: id), mode: .write)
+    let write: EventLoopFuture<Void> = collection.find(["fileId": .int32(id)], options: FindOptions(batchSize: 5000))
+        .flatMap { $0.toArray() }
+        .flatMap { docs in
+            var buffer = allocator.buffer(capacity: docs[0].extendedJSON.utf8.count * 5000)
+            docs.forEach { doc in
+                _ = buffer.writeString(doc.extendedJSON + "\n")
+            }
+            return ioHandler.write(fileHandle: handle, buffer: buffer, eventLoop: eventLoop)
+        }
 
-func runMultiJSONBenchmarks() throws {
+    write.whenComplete { _ in
+        _ = try? handle.close()
+    }
+
+    return write
+}
+
+func runMultiJSONBenchmarks() throws -> (importScore: Double, outputScore: Double) {
     // Setup
     let elg = MultiThreadedEventLoopGroup(numberOfThreads: 4)
     let client = try MongoClient(using: elg)
@@ -65,18 +141,47 @@ func runMultiJSONBenchmarks() throws {
         client.syncShutdown()
     }
     let db = client.db("perftest")
+    let coll = db.collection("corpus")
 
     let threadPool = NIOThreadPool(numberOfThreads: NonBlockingFileIO.defaultThreadPoolSize)
     threadPool.start()
+    defer {
+        try? threadPool.syncShutdownGracefully()
+    }
     let fileIO = NonBlockingFileIO(threadPool: threadPool)
 
-    let coll = try db.drop().flatMap { _ in
-        db.createCollection("corpus")
-    }.wait()
+    let importResult = try measureTask(
+        before: {
+            _ = try db.drop().wait()
+            _ = try db.createCollection("corpus").wait()
+        },
+        task: {
+            try importAllFiles(to: coll, eventLoopGroup: elg, ioHandler: fileIO).wait()
+        }
+    )
 
-    let importResult = try measureOp {
-        try importAllFiles.wait()
-    }
+    let importScore = calculateAndPrintResults(name: "LDJSON Multi-file Import", time: importResult, size: ldJSONSize)
 
-    print("JSON Import Benchmark Result: \(importResult)")
+    // One-time setup for the export benchmark.
+    _ = try db.drop().wait()
+    _ = try importAllFiles(to: coll, eventLoopGroup: elg, ioHandler: fileIO, addFileIds: true).wait()
+    _ = try coll.createIndex(["fileId": .int32(1)]).wait()
+
+    let exportResult = try measureTask(
+        before: {
+            try? FileManager.default.removeItem(atPath: outputPath)
+            try FileManager.default.createDirectory(atPath: outputPath, withIntermediateDirectories: false)
+            (0...99).forEach { id in
+                _ = FileManager.default.createFile(atPath: "\(outputPath)/ldjson\(paddedId(Int32(id))).txt", contents: nil)
+            }
+        },
+        task: {
+            _ = try exportCollection(coll, eventLoopGroup: elg, ioHandler: fileIO).wait()
+        }
+    )
+
+    let outputScore = calculateAndPrintResults(name: "LDJSON Multi-file Export", time: exportResult, size: ldJSONSize)
+    try FileManager.default.removeItem(atPath: outputPath)
+
+    return (importScore: importScore, outputScore: outputScore)
 }

--- a/Sources/Benchmarks/main.swift
+++ b/Sources/Benchmarks/main.swift
@@ -1,2 +1,4 @@
-try benchmarkBSON()
-try benchmarkIO()
+// try benchmarkBSON()
+// try benchmarkIO()
+
+try runJSONImportBenchmark()

--- a/Sources/Benchmarks/main.swift
+++ b/Sources/Benchmarks/main.swift
@@ -1,4 +1,2 @@
-// try benchmarkBSON()
-// try benchmarkIO()
-
-try runJSONImportBenchmark()
+try benchmarkBSON()
+try benchmarkIO()


### PR DESCRIPTION
This implements the LDJSON benchmarks. When I run locally our numbers are very competitive with those recorded in the benchmarks spreadsheet -- ~5.3 seconds on average for import, ~13.5 seconds on average for export.
I could have spent more time tuning all of the parameters here for thread pool sizes and event loop group size but for now this seemed sufficient. I may update them based on my findings in the next ticket to tune the default `NIOThreadPool` size we use.